### PR TITLE
fixing readyness check

### DIFF
--- a/readyness.sh
+++ b/readyness.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if freshclam | grep -q 'bytecode.cvd is up to date'; then
+if freshclam | grep -q 'bytecode.* is up to date'; then
   echo "freshclam running successfully"
   if clamdscan eicar.com | grep -q 'Infected files: 1'; then
     echo "Clamd running successfully"


### PR DESCRIPTION
readyness either stopped working or never worked because the extension is different from what's on the running system.  Wildcarded this