### PR TITLE
Transfer pipelines to new drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,129 +1,110 @@
 pipeline:
   test_build:
-    image: docker:1.11
+    image: docker:17.09.0-ce
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - apk add --no-cache bash sed grep bc coreutils
+      - apk add --no-cache bash sed grep bc coreutils curl
       - ./ci-build.sh
     when:
-      event: [push, pull_request, tag]
+      event: [push, pull_request]
   
   build_clamav:
-    image: docker:1.11
+    image: docker:17.09.0-ce
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker build -t clamav .
+      - docker build -t clamav:$${DRONE_COMMIT_SHA} .
     when:
-      branch: [master, refs/tags/*]
+      branch: master
       event: [push, tag]
   
   build_clamav-rest:
-    image: docker:1.11
+    image: docker:17.09.0-ce
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker build -t clamav-rest clamav-rest
+      - docker build -t clamav-rest:$${DRONE_COMMIT_SHA} clamav-rest
     when:
-      branch: [master, refs/tags/*]
+      branch: master
       event: [push, tag]
-  
+ 
   clamav_to_quay:
-    image: docker:1.11
+    image: docker:17.09.0-ce
+    secrets:
+      - clamav_repo_token
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker login -u="ukhomeofficedigital+drone" -p=${CLAMAV_REPO_TOKEN} quay.io
-      - docker tag clamav quay.io/ukhomeofficedigital/clamav:${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/clamav:${DRONE_COMMIT_SHA}
-    when:
-      branch: [master, refs/tags/*]
-      event: [push, tag]
-  
-  clamav-rest_to_quay:
-    image: docker:1.11
-    environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
-    commands:
-      - docker login -u="ukhomeofficedigital+drone" -p=${CLAMAV_REPO_TOKEN} quay.io
-      - docker tag clamav-rest quay.io/ukhomeofficedigital/clamav-rest:${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/clamav-rest:${DRONE_COMMIT_SHA}
-    when:
-      branch: [master, refs/tags/*]
-      event: [push, tag]
-  
-  trigger_deploy_to_platform-services_dev:
-    image: quay.io/ukhomeofficedigital/kd:v0.2.2
-    environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
-    commands:
-      - kd --insecure-skip-tls-verify --namespace=virus-scan --kube-server=https://kube-dev.dsp.notprod.homeoffice.gov.uk --retries 50 --kube-token=${KUBE_TOKEN_DEV} --file k8s/clamd-api.yaml
+      - docker login -u="ukhomeofficedigital+drone" -p=$${CLAMAV_REPO_TOKEN} quay.io
+      - docker tag clamav:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/clamav:$${DRONE_COMMIT_SHA}
+      - docker tag clamav:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/clamav:latest
+      - docker push quay.io/ukhomeofficedigital/clamav:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/clamav:latest
     when:
       branch: master
       event: push
-
-  build_clamav:
-    image: docker:1.11
+ 
+  tagged_clamav_to_quay:
+    image: docker:17.09.0-ce
+    secrets:
+      - clamav_repo_token
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker build -t clamav .
-    when:
-      event: tag
-  
-  build_clamav-rest:
-    image: docker:1.11
-    environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
-    commands:
-      - docker build -t clamav-rest clamav-rest
-    when:
-      event: tag  
-  clamav_to_quay:
-    image: docker:1.11
-    environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
-    commands:
-      - docker login -u="ukhomeofficedigital+drone" -p=${CLAMAV_REPO_TOKEN} quay.io
-      - docker tag clamav quay.io/ukhomeofficedigital/clamav:${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/clamav:${DRONE_COMMIT_SHA}
+      - docker login -u="ukhomeofficedigital+drone" -p=$${CLAMAV_REPO_TOKEN} quay.io
+      - docker tag clamav:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/clamav:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/clamav:$${DRONE_TAG}
     when:
       event: tag
   
   clamav-rest_to_quay:
-    image: docker:1.11
+    image: docker:17.09.0-ce
+    secrets:
+      - clamav_repo_token
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker login -u="ukhomeofficedigital+drone" -p=${CLAMAV_REPO_TOKEN} quay.io
-      - docker tag clamav-rest quay.io/ukhomeofficedigital/clamav-rest:${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/clamav-rest:${DRONE_COMMIT_SHA}
+      - docker login -u="ukhomeofficedigital+drone" -p=$${CLAMAV_REPO_TOKEN} quay.io
+      - docker tag clamav-rest:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/clamav-rest:$${DRONE_COMMIT_SHA}
+      - docker tag clamav-rest:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/clamav-rest:latest
+      - docker push quay.io/ukhomeofficedigital/clamav-rest:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/clamav-rest:latest
+    when:
+      branch: master
+      event: push
+  
+  tagged_clamav-rest_to_quay:
+    image: docker:17.09.0-ce
+    secrets:
+      - clamav_repo_token
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker login -u="ukhomeofficedigital+drone" -p=$${CLAMAV_REPO_TOKEN} quay.io
+      - docker tag clamav-rest:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/clamav-rest:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/clamav-rest:$${DRONE_TAG}
     when:
       event: tag
-  
+ 
   trigger_deploy_to_platform-services_dev:
     image: quay.io/ukhomeofficedigital/kd:v0.2.2
+    secrets:
+      - kube_token_dev
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - kd --insecure-skip-tls-verify --namespace=virus-scan --kube-server=https://kube-dev.dsp.notprod.homeoffice.gov.uk --retries 50 --kube-token=${KUBE_TOKEN_DEV} --file k8s/clamd-api.yaml
+      - kd --insecure-skip-tls-verify --namespace=virus-scan --kube-server=https://kube-dev.dsp.notprod.homeoffice.gov.uk --retries 50 --kube-token=$${KUBE_TOKEN_DEV} --file k8s/clamd-api.yaml
     when:
-      event: tag
-
+      event: deploy
+ 
   trigger_deploy_to_platform-services_prod:
     image: quay.io/ukhomeofficedigital/kd:v0.2.2
+    secrets:
+      - kube_token_prod
     environment:
-      - DOCKER_HOST=tcp://127.0.0.1:2375
+      - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - kd --insecure-skip-tls-verify --namespace=virus-scan --kube-server=https://kube.dsp.digital.homeoffice.gov.uk --retries 50 --kube-token=${KUBE_TOKEN_PROD} --file k8s/clamd-api.yaml
+      - kd --insecure-skip-tls-verify --namespace=virus-scan --kube-server=https://kube.dsp.digital.homeoffice.gov.uk --retries 50 --kube-token=$${KUBE_TOKEN_PROD} --file k8s/clamd-api.yaml
     when:
-      event: tag
-      
-services:
-  dind:
-    image: docker:1.11-dind
-    privileged: true
-    command:
-      - "-s"
-      - "overlay"
+      event: deploy

--- a/.drone.yml.sig
+++ b/.drone.yml.sig
@@ -1,1 +1,0 @@
-eyJhbGciOiJIUzI1NiJ9.e30K.pGl_bOFvm-UOV6VGx7on2jkmZ0vHNLkXlObYqFycD2U


### PR DESCRIPTION
Notes: The database that this pulls from to update some of the files is not reliable. i.e. It randomly fails with a 404 sometimes when trying to pull the files.

`kube_token_dev` has not been added to new drone because I have no idea what it is. So when this needs to be deployed the secret will need to be added first. Same with `kube_token_prod`.