### PR TITLE
Permissions on config-files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,17 +26,18 @@ RUN wget -t 5 -T 99999 -O /var/lib/clamav/main.cvd http://database.clamav.net/ma
     wget -t 5 -T 99999 -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
     chown clamav:clamav /var/lib/clamav/*.cvd
 
-# permissions
-RUN mkdir /var/run/clamav && \
-    chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
-
-USER clamav
-
 # Configure Clam AV...
 ADD ./*.conf /usr/local/etc/
 ADD eicar.com /
 ADD ./readyness.sh /
+
+# permissions
+RUN mkdir /var/run/clamav && \
+    chown clamav:clamav /var/run/clamav && \
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav /usr/local/etc
+
+USER clamav
 
 VOLUME /var/lib/clamav
 


### PR DESCRIPTION
Fix permissions on config-files so CLAMD_SETTINGS_CSV and FRESHCLAM_SETTINGS_CSV actually work.

When I try to alter settings by using CLAMD_SETTINGS_CSV and FRESHCLAM_SETTINGS_CSV I get permission-denied errors and no config is changed. This is because the /usr/local/etc folder and all contents in it are owned by root instead of clamav.