### PR TITLE
changing the clamav version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-ENV CLAM_VERSION=0.102.1-r0
+ENV CLAM_VERSION=0.102.3-r0
 
 RUN apk add --no-cache clamav=$CLAM_VERSION clamav-libunrar=$CLAM_VERSION
 


### PR DESCRIPTION
Issue and Fix -  ERROR: unsatisfiable constraints: clamav-0.102.3-r0: breaks: world[clamav=0.102.1-r0]

Issue:

When I tired pulling the code to my local environment and build using docker build command..

Got the below error:

ERROR: unsatisfiable constraints:
  clamav-0.102.3-r0:
    breaks: world[clamav=0.102.1-r0]
  clamav-libunrar-0.102.3-r0:
    breaks: world[clamav-libunrar=0.102.1-r0]
The command '/bin/sh -c apk add --no-cache clamav=$CLAM_VERSION clamav-libunrar=$CLAM_VERSION' returned a non-zero code: 2

Fix:

And got fixed by changing the clam version in docker file :
ENV CLAM_VERSION=0.102.1-r0   to latest version available ENV CLAM_VERSION=0.102.3-r0.

New version am referring from : https://pkgs.alpinelinux.org/packages?name=clamav-libunrar&branch=edge